### PR TITLE
#312 setup docs auto-deploy

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,28 @@
+name: Deploy docs to GitHub pages
+on:
+  push:
+    # Every push on dev will run this action below
+    branches: [dev]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    concurrency: ci-${{github.ref}}
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+
+      - name: Install dependencies and Generate static docs files
+        run: |
+          npm ci
+          npx ts-node ./docs-generator/main.ts
+
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: docs
+          branch: gh-pages


### PR DESCRIPTION
To see this action running, you can check out my repository [here](https://github.com/GeraldWicks/docs-test), where I could run this action and checkout if was working properly.

 So basically, this GitHub action will run every time we push something into branch `dev`, then this action will:
 -> generate the `docs` folder, and it will push the `docs` folder into `gh-pages` branch
 
 why do we need to push into another branch? because we will not have all these docs files inside `dev`, only on the `gh-pages` branch.
 
 To publish the docs page, we just need to go to:
settings -> pages
then change the branch source to `gh-pages`

Exactly like that:
![captura_de_tela_de_2022-05-26_13-35-08](https://user-images.githubusercontent.com/69917459/170539481-8685b75e-7aa3-45a2-9006-5c1ef7ef8b63.png)


At the end of the day, every time a new push is done into the `dev` branch, the docs website will be updated.

