### PR TITLE
#330 The playbook.name can be null but we don't validate that on the isPlaybook method

### DIFF
--- a/src/models/playbook/is-playbook.ts
+++ b/src/models/playbook/is-playbook.ts
@@ -18,7 +18,7 @@ export const isPlaybook = (value: any): value is Playbook => {
 			isUUID(p.globalID) &&
 			isNumericID(p.userID) &&
 			p.groupIDs.every(isNumericID) &&
-			isString(p.name) &&
+			(isString(p.name) || isNull(p.name)) &&
 			(isString(p.description) || isNull(p.description)) &&
 			p.labels.every(isString) &&
 			isBoolean(p.isGlobal) &&


### PR DESCRIPTION
Adresses: [#330](https://github.com/gravwell/js-client/issues/330)

To test if was working correctly, I wrote the following code:
![code](https://user-images.githubusercontent.com/69917459/173439289-a2c0dd00-1f78-4463-aa2c-43d656d758c1.png)


Before the implementation, it falls to the case `it is not a playbook`
![beforeImplementation](https://user-images.githubusercontent.com/69917459/173437252-0863c5d8-9f0d-4ec7-90bf-eed8d217fb0a.png)


After the implementation, it falls to the case `it is a playbook`:
![afterImplementation](https://user-images.githubusercontent.com/69917459/173438701-59d4e751-aa94-4777-bf7f-ca2617a9b5b8.png)


