### PR TITLE
#336 Can't fetch a template just after creation. 

### DIFF
--- a/.config/test-config/test-backend-alpha/Dockerfile
+++ b/.config/test-config/test-backend-alpha/Dockerfile
@@ -4,7 +4,7 @@ FROM gravwell/gravwell:latest AS gravwell-stable
 
 FROM base AS gravwell
 
-RUN apt-get update && apt-get --yes install curl gnupg2
+RUN apt-get update && apt-get --yes install curl gnupg2 wget
 RUN wget -O /usr/share/keyrings/gravwell.asc https://gin.gravwell.io/debianalphaXYZZY/gin.gravwell.io.gpg.key
 RUN echo 'deb [ arch=amd64 signed-by=/usr/share/keyrings/gravwell.asc ] https://gin.gravwell.io/debianalphaXYZZY community main' > /etc/apt/sources.list.d/gravwell.list
 RUN apt-get update && apt-get --yes install \

--- a/.config/test-config/test-backend-alpha/Dockerfile
+++ b/.config/test-config/test-backend-alpha/Dockerfile
@@ -5,8 +5,8 @@ FROM gravwell/gravwell:latest AS gravwell-stable
 FROM base AS gravwell
 
 RUN apt-get update && apt-get --yes install curl gnupg2
-RUN curl https://update.gravwell.io/debian/update.gravwell.io.gpg.key | apt-key add -
-RUN echo 'deb [ arch=amd64 ] https://update.gravwell.io/debianalphaXYZZY/ community main' | tee /etc/apt/sources.list.d/gravwell.list
+RUN wget -O /usr/share/keyrings/gravwell.asc https://gin.gravwell.io/debianalphaXYZZY/gin.gravwell.io.gpg.key
+RUN echo 'deb [ arch=amd64 signed-by=/usr/share/keyrings/gravwell.asc ] https://gin.gravwell.io/debianalphaXYZZY community main' > /etc/apt/sources.list.d/gravwell.list
 RUN apt-get update && apt-get --yes install \
   apt-transport-https gravwell
 

--- a/src/functions/templates/create-one-template.ts
+++ b/src/functions/templates/create-one-template.ts
@@ -6,7 +6,7 @@
  * MIT license. See the LICENSE file for details.
  **************************************************************************/
 
-import { CreatableTemplate, Template, toRawCreatableTemplate } from '~/models';
+import { CreatableTemplate, RawTemplate, Template, toRawCreatableTemplate, toTemplate } from '~/models';
 import { UUID } from '~/value-objects';
 import {
 	APIContext,
@@ -15,11 +15,8 @@ import {
 	HTTPRequestOptions,
 	parseJSONResponse,
 } from '../utils';
-import { makeGetOneTemplate } from './get-one-template';
 
 export const makeCreateOneTemplate = (context: APIContext) => {
-	const getOneTemplate = makeGetOneTemplate(context);
-
 	const templatePath = '/api/templates';
 	const url = buildURL(templatePath, { ...context, protocol: 'http' });
 
@@ -31,10 +28,9 @@ export const makeCreateOneTemplate = (context: APIContext) => {
 			const req = buildHTTPRequestWithAuthFromContext(context, baseRequestOptions);
 
 			const raw = await context.fetch(url, { ...req, method: 'POST' });
-			const rawID = await parseJSONResponse<UUID>(raw);
+			const rawRes = await parseJSONResponse<RawTemplate>(raw);
 
-			const templateID = rawID.toString();
-			return await getOneTemplate(templateID);
+			return toTemplate(rawRes);
 		} catch (err) {
 			if (err instanceof Error) throw err;
 			throw Error('Unknown error');

--- a/src/functions/templates/create-one-template.ts
+++ b/src/functions/templates/create-one-template.ts
@@ -7,7 +7,6 @@
  **************************************************************************/
 
 import { CreatableTemplate, RawTemplate, Template, toRawCreatableTemplate, toTemplate } from '~/models';
-import { UUID } from '~/value-objects';
 import {
 	APIContext,
 	buildHTTPRequestWithAuthFromContext,

--- a/src/functions/templates/get-one-template.ts
+++ b/src/functions/templates/get-one-template.ts
@@ -14,13 +14,9 @@ export const makeGetOneTemplate = (context: APIContext) => {
 	return async (templateID: NumericID): Promise<Template> => {
 		const templatePath = '/api/templates/{templateID}';
 		const url = buildURL(templatePath, { ...context, protocol: 'http', pathParams: { templateID } });
-		console.log('---- getOneTemplate ----');
 		const req = buildHTTPRequestWithAuthFromContext(context);
-		console.log('req = ', req);
 		const raw = await context.fetch(url, { ...req, method: 'GET' });
-		console.log('raw = ', raw);
 		const rawRes = await parseJSONResponse<RawTemplate>(raw);
-		console.log('rawRes = ', rawRes);
 		return toTemplate(rawRes);
 	};
 };

--- a/src/functions/templates/get-one-template.ts
+++ b/src/functions/templates/get-one-template.ts
@@ -14,11 +14,13 @@ export const makeGetOneTemplate = (context: APIContext) => {
 	return async (templateID: NumericID): Promise<Template> => {
 		const templatePath = '/api/templates/{templateID}';
 		const url = buildURL(templatePath, { ...context, protocol: 'http', pathParams: { templateID } });
-
+		console.log('---- getOneTemplate ----');
 		const req = buildHTTPRequestWithAuthFromContext(context);
-
+		console.log('req = ', req);
 		const raw = await context.fetch(url, { ...req, method: 'GET' });
+		console.log('raw = ', raw);
 		const rawRes = await parseJSONResponse<RawTemplate>(raw);
+		console.log('rawRes = ', rawRes);
 		return toTemplate(rawRes);
 	};
 };

--- a/src/functions/templates/get-one-template.ts
+++ b/src/functions/templates/get-one-template.ts
@@ -14,7 +14,9 @@ export const makeGetOneTemplate = (context: APIContext) => {
 	return async (templateID: NumericID): Promise<Template> => {
 		const templatePath = '/api/templates/{templateID}';
 		const url = buildURL(templatePath, { ...context, protocol: 'http', pathParams: { templateID } });
+
 		const req = buildHTTPRequestWithAuthFromContext(context);
+
 		const raw = await context.fetch(url, { ...req, method: 'GET' });
 		const rawRes = await parseJSONResponse<RawTemplate>(raw);
 		return toTemplate(rawRes);


### PR DESCRIPTION
Adresses: [#336](https://github.com/gravwell/js-client/issues/336)

Important to say that, the issue was even bigger, than what was described on `gitea`, so when any template was created, an 400 request was received and didn't go to `/templates` page after click on save button. (And probably that's why drone was failing on template tests)

https://user-images.githubusercontent.com/69917459/173917689-1683d244-677f-4625-9dab-7c1405c393b2.mp4


With the current solution, beyond the fact the template is working, and drone will probably be fixed, now we do one request (create one template) to the back-end instead of two (create one template and get one template).

After the implementation, here is the behavior on template page (add, edit and delete works correctly):

https://user-images.githubusercontent.com/69917459/173919580-54545f06-5111-4331-9330-e92a4bdbc9d2.mp4




