### PR TITLE
#343 Replace the `templatePath` to `/api/autoextractors/test`

### DIFF
--- a/src/functions/auto-extractors/is-valid-auto-extractor-syntax.ts
+++ b/src/functions/auto-extractors/is-valid-auto-extractor-syntax.ts
@@ -16,7 +16,7 @@ import {
 } from '../utils';
 
 export const makeIsValidAutoExtractorSyntax = (context: APIContext) => {
-	const templatePath = '/api/autoextractors/test';
+	const templatePath = '/api/autoextractors';
 	const url = buildURL(templatePath, { ...context, protocol: 'http' });
 
 	return async (data: CreatableAutoExtractor): Promise<IsValidAutoExtractorSyntaxResponse> => {

--- a/src/functions/auto-extractors/is-valid-auto-extractor-syntax.ts
+++ b/src/functions/auto-extractors/is-valid-auto-extractor-syntax.ts
@@ -16,7 +16,7 @@ import {
 } from '../utils';
 
 export const makeIsValidAutoExtractorSyntax = (context: APIContext) => {
-	const templatePath = '/api/autoextractors';
+	const templatePath = '/api/autoextractors/test';
 	const url = buildURL(templatePath, { ...context, protocol: 'http' });
 
 	return async (data: CreatableAutoExtractor): Promise<IsValidAutoExtractorSyntaxResponse> => {


### PR DESCRIPTION
Adresses: [#343](https://github.com/gravwell/js-client/issues/343)

**To test if was working correcly I wrote the following code on  the front-end gravgui:**

![Captura de tela de 2022-06-20 17-34-36](https://user-images.githubusercontent.com/69917459/174674554-95436052-62cc-4041-bf14-17f5bcfc6211.png)
![Captura de tela de 2022-06-20 17-34-42](https://user-images.githubusercontent.com/69917459/174674556-7105f4b0-0367-4adc-bcc8-2f5f27001d64.png)
![Captura de tela de 2022-06-20 17-34-48](https://user-images.githubusercontent.com/69917459/174674557-b89ea79c-478c-4f80-9a16-0985e7adc661.png)

**Before the implementation, this was the console output:**

![Captura de tela de 2022-06-20 17-28-38](https://user-images.githubusercontent.com/69917459/174674589-398f72e8-d532-443f-852d-50d2122fde55.png)

**After the implementation, this is the console output:**

![Captura de tela de 2022-06-20 17-32-55](https://user-images.githubusercontent.com/69917459/174674643-4e23779d-05e3-4be2-a8dd-097f41227b5f.png)

